### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -24,7 +24,7 @@ class action_plugin_columns extends DokuWiki_Action_Plugin {
     /**
      * Register callbacks
      */
-    public function register(&$controller) {
+    public function register(Doku_Event_Handler $controller) {
         $controller->register_hook('PARSER_HANDLER_DONE', 'AFTER', $this, 'handle');
     }
 

--- a/syntax.php
+++ b/syntax.php
@@ -76,7 +76,7 @@ class syntax_plugin_columns extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    public function handle($match, $state, $pos, &$handler) {
+    public function handle($match, $state, $pos, Doku_Handler $handler) {
         foreach ($this->syntax as $state => $pattern) {
             if (preg_match($pattern, $match, $data) == 1) {
                 break;
@@ -96,7 +96,7 @@ class syntax_plugin_columns extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    public function render($mode, &$renderer, $data) {
+    public function render($mode, Doku_Renderer $renderer, $data) {
         if ($mode == 'xhtml') {
             switch ($data[0]) {
                 case DOKU_LEXER_ENTER:


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.